### PR TITLE
Add feature to add expected file to checklist from command line

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,3 +41,7 @@ run:
 clean:
 	# Remove virtual environment
 	# rm -rf $(VENV_NAME)
+
+add:
+	# Add a new expected file to the checklist
+	$(PYTHON_INTERPRETER) add_to_checklist.py $(file_name)

--- a/README.md
+++ b/README.md
@@ -47,3 +47,25 @@ Sort on Delivery Status: Missing, Delivered, Unknown
 //Not before --post
 Sometimes documents need to be updated to be counted.
 --post can be passed from command line or setup in the checklist
+
+## Adding New Expected Files to the Checklist
+
+You can add new expected files to the checklist from the command line using the `add_to_checklist.py` script. This script will add the specified file to the `checklist.txt` if it does not already exist.
+
+### Usage
+
+To add a new expected file to the checklist, run the following command:
+
+```sh
+python add_to_checklist.py <file_name>
+```
+
+Replace `<file_name>` with the name of the file you want to add to the checklist.
+
+### Example
+
+```sh
+python add_to_checklist.py "ITR - FY2019-20 - 25a - New Document.pdf"
+```
+
+This command will add the file "ITR - FY2019-20 - 25a - New Document.pdf" to the `checklist.txt` if it does not already exist.

--- a/add_to_checklist.py
+++ b/add_to_checklist.py
@@ -1,0 +1,24 @@
+import sys
+
+def add_to_checklist(file_name):
+    checklist_file = 'checklist.txt'
+    
+    with open(checklist_file, 'r') as file:
+        checklist = file.read().splitlines()
+    
+    if file_name in checklist:
+        print(f"{file_name} already exists in the checklist.")
+        return
+    
+    with open(checklist_file, 'a') as file:
+        file.write(file_name + '\n')
+    
+    print(f"{file_name} has been added to the checklist.")
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("Usage: python add_to_checklist.py <file_name>")
+        sys.exit(1)
+    
+    file_name = sys.argv[1]
+    add_to_checklist(file_name)


### PR DESCRIPTION
Add a new feature to allow users to add a new expected file to the checklist from the command line.

* **add_to_checklist.py**
  - Create a new script to handle adding new expected files to the checklist.
  - Check if the file already exists in `checklist.txt` and ignore duplicates.
  - Add the file to `checklist.txt` if it does not exist.

* **README.md**
  - Add a new section describing the usage of `add_to_checklist.py`.
  - Include instructions for using the new feature to add expected files from the command line.

* **Makefile**
  - Add a new target `add` that runs the `add_to_checklist.py` script with the provided file name.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/radlakha/checklist/pull/1?shareId=cb9544de-b5dc-4aa0-b32d-64ae93df48a5).